### PR TITLE
added support for multiple sortable lists.

### DIFF
--- a/nativesortable.js
+++ b/nativesortable.js
@@ -1,4 +1,3 @@
-
 // nativesortable
 // Author: Brian Grinstead MIT License
 // Originally based on code found here:
@@ -126,6 +125,8 @@ nativesortable = (function() {
                 e.dataTransfer.setData('Text', "*"); // Need to set to something or else drag doesn't start
             }
             
+            // save the current drag item to a global var which can be checked by all native sortable lists on the page
+            dragitem = this;
             currentlyDraggingElement = this;
             addClassName(currentlyDraggingElement, DRAGGING_CLASS);
             
@@ -151,6 +152,16 @@ nativesortable = (function() {
         });
         
         var handleDragEnter = delegate(function(e) {
+            
+            // check if the drop target is the same list as the draggable item
+        	if (dragitem) {
+    			if (element != dragitem.parentNode) {
+    				// clone the item into the list
+    				currentlyDraggingElement = dragitem.cloneNode(true);
+    				element.appendChild(currentlyDraggingElement);
+    				dragitem = null;
+    			}
+    		}
         
             if (!currentlyDraggingElement || currentlyDraggingElement === this) {
                 return true;


### PR DESCRIPTION
Nice plugin, thought it would make sense to allow dragging between multiple native sortables on the same page. Changed so it always save the current drag item to a variable that all sortables can check themselves against. Then if the draggable's parent is different the item is cloned into to the new list and sorted accordingly
