### PR TITLE
Add universal module definition

### DIFF
--- a/nativesortable.js
+++ b/nativesortable.js
@@ -12,7 +12,15 @@
  * @license MIT License
  */
 
-nativesortable = (function() {
+(function(definition) {
+    if(typeof exports === 'object') {
+        module.exports = definition();
+    } else if(typeof define === 'function' && define.amd) {
+        define([], definition);
+    } else {
+        window.nativesortable = definition();
+    }
+})(function() {
 
     var supportsTouch = ('ontouchstart' in window) || (window.DocumentTouch && document instanceof DocumentTouch);
     var supportsDragAndDrop = !supportsTouch && (function() {
@@ -336,4 +344,4 @@ nativesortable = (function() {
         });
 
     };
-}());
+});


### PR DESCRIPTION
This allows nativesortable to be used with CommonJS-like module systems (e.g. Browserify), RequireJS, and included as a script tag.
